### PR TITLE
Fix typo in directory name in download_hf.sh

### DIFF
--- a/download/download_hf.sh
+++ b/download/download_hf.sh
@@ -1,4 +1,4 @@
 mkdir -p ./checkpoints/
-cd ./downlod
+cd ./download
 python download_hf.py
 cd ..


### PR DESCRIPTION
## Description
This is a small PR that fixes a typo in the `download/download_hf.sh` script. Specifically, it corrects `cd ./downlod` → `cd ./download`.

## Motivation
Tried running the script on Google Colab.